### PR TITLE
Setup update

### DIFF
--- a/.github/workflows/user_project_ci.yml
+++ b/.github/workflows/user_project_ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  download_caravel:
+  download_deps:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,95 +33,61 @@ jobs:
         run: |
           sudo mkdir -p ${{ env.PDK_ROOT }}
           sudo chown -R $USER:$USER ${{ env.PDK_ROOT }}
-          make install
+          make setup
+          cd ${{ env.MCW_ROOT }}
+          rm -rf gds maglef openlane spi LICENSE manifest docs litex lvs .git
           cd ${{ env.CARAVEL_ROOT }}
           rm -rf gds maglef openlane spi LICENSE manifest .git
 
       - name: Tarball Caravel
         run: |
-          tar -cf /tmp/caravel.tar -C $CARAVEL_ROOT .
+          tar -cf /tmp/caravel.tar -C ${{ env.CARAVEL_ROOT }} .
 
       - name: Upload Caravel Tarball
         uses: actions/upload-artifact@v2
         with:
           name: caravel-tarball
           path: /tmp/caravel.tar
-  
-  download_deps:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        targets: ["pdk-with-volare", "install_mcw", "openlane", "setup-timing-scripts", "precheck"]
-    needs: [download_caravel]
-    steps:
-      - uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Setup Environment Variables
+      - name: Tarball mgmt_core_wrapper
         run: |
-          echo "PDK_ROOT=$GITHUB_WORKSPACE/pdk" >> $GITHUB_ENV
-          echo "OPENLANE_ROOT=$GITHUB_WORKSPACE/openlane_src" >> $GITHUB_ENV
-          echo "CARAVEL_ROOT=$GITHUB_WORKSPACE/caravel" >> $GITHUB_ENV
-          echo "MCW_ROOT=$GITHUB_WORKSPACE/mgmt_core_wrapper" >> $GITHUB_ENV
-          echo "TIMING_ROOT=$GITHUB_WORKSPACE/timing-scripts" >> $GITHUB_ENV
-          echo "PRECHECK_ROOT=$GITHUB_WORKSPACE/mpw_precheck" >> $GITHUB_ENV
-          echo "MPW_TAG=main" >> $GITHUB_ENV
-      
-      - name: Get dependencies name
-        run: |
-          if [[ "${{ matrix.targets }}" == "install_mcw" ]]; then
-            echo "dep_name=mgmt_core_wrapper" >> $GITHUB_ENV
-            echo "dep_root=${{ env.MCW_ROOT }}" >> $GITHUB_ENV
-          elif [[ "${{ matrix.targets }}" == "openlane" ]]; then
-            echo "dep_name=openlane" >> $GITHUB_ENV
-            echo "dep_root=${{ env.OPENLANE_ROOT }}" >> $GITHUB_ENV
-          elif [[ "${{ matrix.targets }}" == "pdk-with-volare" ]]; then
-            echo "dep_name=pdk" >> $GITHUB_ENV
-            echo "dep_root=${{ env.PDK_ROOT }}" >> $GITHUB_ENV
-          elif [[ "${{ matrix.targets }}" == "setup-timing-scripts" ]]; then
-            echo "dep_name=timing-scripts" >> $GITHUB_ENV
-            echo "dep_root=${{ env.TIMING_ROOT }}" >> $GITHUB_ENV
-          elif [[ "${{ matrix.targets }}" == "precheck" ]]; then
-            echo "dep_name=precheck" >> $GITHUB_ENV
-            echo "dep_root=${{ env.PRECHECK_ROOT }}" >> $GITHUB_ENV
-          fi
+          tar -cf /tmp/mgmt_core_wrapper.tar -C ${{ env.MCW_ROOT }} .
 
-      - name: Download caravel Tarball
-        uses: actions/download-artifact@v2
-        with:
-          name: caravel-tarball
-          path: /tmp
-
-      - name: Unpack caravel Tarball
-        run: |
-          sudo mkdir -p ${{ env.CARAVEL_ROOT }}
-          sudo chown -R $USER:$USER ${{ env.CARAVEL_ROOT }}
-          tar -xf /tmp/caravel.tar -C $CARAVEL_ROOT .
-
-      - name: Install dependencies
-        run: |
-          sudo mkdir -p ${{ env.PDK_ROOT }}
-          sudo chown -R $USER:$USER ${{ env.PDK_ROOT }}
-          make ${{ matrix.targets }}
-          if [[ "${{ env.dep_name }}" == "mgmt_core_wrapper" ]]; then
-            cd ${{ env.dep_root }}
-            rm -rf gds maglef openlane spi LICENSE manifest docs litex lvs .git
-          fi
-
-      - name: Tarball Dependencies
-        run: |
-          tar -cf /tmp/${{ env.dep_name }}.tar -C ${{ env.dep_root }} .
-
-      - name: Upload Dependencies Tarball
+      - name: Upload mgmt_core_wrapper Tarball
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.dep_name }}-tarball
-          path: /tmp/${{ env.dep_name }}.tar
+          name: mgmt_core_wrapper-tarball
+          path: /tmp/mgmt_core_wrapper.tar
+
+      - name: Tarball openlane
+        run: |
+          tar -cf /tmp/openlane.tar -C ${{ env.OPENLANE_ROOT }} .
+
+      - name: Upload openlane Tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: openlane-tarball
+          path: /tmp/openlane.tar
+
+      - name: Tarball pdk
+        run: |
+          tar -cf /tmp/pdk.tar -C ${{ env.PDK_ROOT }} .
+
+      - name: Upload pdk Tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: pdk-tarball
+          path: /tmp/pdk.tar
+
+      - name: Tarball timing_scripts
+        run: |
+          tar -cf /tmp/timing_scripts.tar -C ${{ env.TIMING_ROOT }} .
+
+      - name: Upload timing_scripts Tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: timing_scripts-tarball
+          path: /tmp/timing_scripts.tar
 
   hardening:
     timeout-minutes: 720
@@ -469,91 +435,3 @@ jobs:
             echo "STA run passed"
             exit 0
           fi
-  
-  # GL-verification:
-  #   timeout-minutes: 720
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       pdk: ["sky130A", "sky130B"]
-  #   needs: [download_deps]
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v1
-
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v1
-
-  #     - name: Export ENVIRONMENT VARIABLES
-  #       run: |
-  #         echo "PDK=${{ matrix.pdk }}" >> $GITHUB_ENV
-  #         echo "PDKPATH=$GITHUB_WORKSPACE/pdk/${{ matrix.pdk }}" >> $GITHUB_ENV
-  #         echo "PDK_ROOT=$GITHUB_WORKSPACE/pdk" >> $GITHUB_ENV
-  #         echo "OPENLANE_ROOT=$GITHUB_WORKSPACE/openlane_src" >> $GITHUB_ENV
-  #         echo "CARAVEL_ROOT=$GITHUB_WORKSPACE/caravel" >> $GITHUB_ENV
-  #         echo "MCW_ROOT=$GITHUB_WORKSPACE/mgmt_core_wrapper" >> $GITHUB_ENV
-  #         echo "TIMING_ROOT=$GITHUB_WORKSPACE/timing-scripts" >> $GITHUB_ENV
-  #         echo "PRECHECK_ROOT=$GITHUB_WORKSPACE/mpw_precheck" >> $GITHUB_ENV
-  #         echo "MPW_TAG=main" >> $GITHUB_ENV
-
-  #     - name: Download PDK Tarball
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: pdk-tarball
-  #         path: /tmp
-
-  #     - name: Unpack PDK Tarball
-  #       run: |
-  #         sudo mkdir -p ${{ env.PDK_ROOT }}
-  #         sudo chown -R $USER:$USER ${{ env.PDK_ROOT }}
-  #         tar -xf /tmp/pdk.tar -C $PDK_ROOT .
-      
-  #     - name: Download caravel Tarball
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: caravel-tarball
-  #         path: /tmp
-
-  #     - name: Unpack caravel Tarball
-  #       run: |
-  #         sudo mkdir -p ${{ env.CARAVEL_ROOT }}
-  #         sudo chown -R $USER:$USER ${{ env.CARAVEL_ROOT }}
-  #         tar -xf /tmp/caravel.tar -C $CARAVEL_ROOT .
-      
-  #     - name: Download mgmt_core_wrapper Tarball
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: mgmt_core_wrapper-tarball
-  #         path: /tmp
-
-  #     - name: Unpack mgmt_core_wrapper Tarball
-  #       run: |
-  #         sudo mkdir -p ${{ env.MCW_ROOT }}
-  #         sudo chown -R $USER:$USER ${{ env.MCW_ROOT }}
-  #         tar -xf /tmp/mgmt_core_wrapper.tar -C $MCW_ROOT .
-
-  #     # - name: Download Design Tarball
-  #     #   uses: actions/download-artifact@v2
-  #     #   with:
-  #     #     name: design-tarball
-  #     #     path: /tmp
-
-  #     # - name: Unpack Design Tarball
-  #     #   run: |
-  #     #     sudo mkdir -p $GITHUB_WORKSPACE
-  #     #     sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-  #     #     tar -xf /tmp/design.tar -C $GITHUB_WORKSPACE .
-
-  #     - name: install cocotb
-  #       run: |
-  #         make setup-cocotb
-      
-  #     - name: run RTL verification
-  #       run: |
-  #         cd $GITHUB_WORKSPACE/verilog/dv/cocotb && $GITHUB_WORKSPACE/venv-cocotb/bin/caravel_cocotb -tl user_proj_tests/user_proj_tests_gl.yaml -verbosity debug --CI  -tag gl_verification
-  #         cnt=$(grep -c "failed" "$GITHUB_WORKSPACE/verilog/dv/cocotb/sim/gl_verification/runs.log")
-  #         if ! [[ $cnt ]]; then cnt=0; fi
-  #         if [[ $cnt -eq 1 ]]; then exit 0; fi
-  #         exit 2

--- a/.github/workflows/user_project_ci.yml
+++ b/.github/workflows/user_project_ci.yml
@@ -153,6 +153,7 @@ jobs:
 
       - name: Harden using Openlane
         run: |
+          curl https://raw.githubusercontent.com/efabless/central_CI/main/tools.json > tool_versions.json
           python3 $GITHUB_WORKSPACE/.github/scripts/get_designs.py --design $GITHUB_WORKSPACE
           for word in $(cat harden_sequence.txt); do
             echo "CURRENT_DESIGN=${word}" >> $GITHUB_ENV
@@ -425,6 +426,7 @@ jobs:
       
       - name: Run STA
         run: |
+          curl https://raw.githubusercontent.com/efabless/central_CI/main/tools.json > tool_versions.json
           export CUP_ROOT=$GITHUB_WORKSPACE
           export PROJECT_ROOT=$GITHUB_WORKSPACE
           cd $CUP_ROOT

--- a/.github/workflows/user_project_ci.yml
+++ b/.github/workflows/user_project_ci.yml
@@ -146,7 +146,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/.github/scripts/get_designs.py --design $GITHUB_WORKSPACE
           for word in $(cat harden_sequence.txt); do
             echo "CURRENT_DESIGN=${word}" >> $GITHUB_ENV
-            make $word
+            DISABLE_VERSION_CHECK=1 make $word
           done
           rm -rf openlane/user_proj_example/runs openlane/user_project_wrapper/runs pdk openlane_src caravel mgmt_core_wrapper timing-scripts mpw_precheck
 
@@ -238,7 +238,7 @@ jobs:
 
       - name: install cocotb
         run: |
-          make setup-cocotb
+          DISABLE_VERSION_CHECK=1 make setup-cocotb
       
       - name: run RTL verification
         run: |
@@ -418,9 +418,9 @@ jobs:
           export CUP_ROOT=$GITHUB_WORKSPACE
           export PROJECT_ROOT=$GITHUB_WORKSPACE
           cd $CUP_ROOT
-          make extract-parasitics
-          make create-spef-mapping
-          make caravel-sta
+          DISABLE_VERSION_CHECK=1 make extract-parasitics
+          DISABLE_VERSION_CHECK=1 make create-spef-mapping
+          DISABLE_VERSION_CHECK=1 make caravel-sta
           tar -cf /tmp/timing.tar $CUP_ROOT/signoff/caravel/openlane-signoff/timing
           find $CUP_ROOT/signoff/caravel/openlane-signoff/timing/*/ -name "summary.log" | head -n1 \
             | xargs head -n5 | tail -n1 > $CUP_ROOT/signoff/caravel/openlane-signoff/timing/all-summary.rpt

--- a/.github/workflows/user_project_ci.yml
+++ b/.github/workflows/user_project_ci.yml
@@ -81,13 +81,23 @@ jobs:
 
       - name: Tarball timing_scripts
         run: |
-          tar -cf /tmp/timing_scripts.tar -C ${{ env.TIMING_ROOT }} .
+          tar -cf /tmp/timing-scripts.tar -C ${{ env.TIMING_ROOT }} .
 
       - name: Upload timing_scripts Tarball
         uses: actions/upload-artifact@v2
         with:
-          name: timing_scripts-tarball
-          path: /tmp/timing_scripts.tar
+          name: timing-scripts-tarball
+          path: /tmp/timing-scripts.tar
+
+      - name: Tarball precheck
+        run: |
+          tar -cf /tmp/precheck.tar -C ${{ env.PRECHECK_ROOT }} .
+
+      - name: Upload precheck Tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: precheck-tarball
+          path: /tmp/precheck.tar
 
   hardening:
     timeout-minutes: 720

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ endif
 export OPENLANE_ROOT?=$(PWD)/dependencies/openlane_src
 export PDK_ROOT?=$(PWD)/dependencies/pdks
 export DISABLE_LVS?=0
+export DISABLE_VERSION_CHECK?=0
 
 export ROOTLESS
 
@@ -65,9 +66,9 @@ ifeq ($(PDK),gf180mcuD)
 endif
 
 # Include Caravel Makefile Targets
-# .PHONY: % : check-caravel
-# %:
-# 	export CARAVEL_ROOT=$(CARAVEL_ROOT) && export MPW_TAG=$(MPW_TAG) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
+.PHONY: % : check-caravel
+%:
+	export CARAVEL_ROOT=$(CARAVEL_ROOT) && export MPW_TAG=$(MPW_TAG) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
 
 # Install DV setup
 .PHONY: simenv
@@ -222,7 +223,11 @@ uninstall:
 
 .PHONY: check_versions
 check_versions:
-	./venv/bin/$(PYTHON_BIN) -u scripts/compare_versions.py
+	@if [ "$$DISABLE_VERSION_CHECK" = "1" ]; then\
+		echo "Skipping version check"; \
+	else \
+		./venv/bin/$(PYTHON_BIN) -u scripts/compare_versions.py; \
+	fi
 # Install Pre-check
 # Default installs to the user home directory, override by "export PRECHECK_ROOT=<precheck-installation-path>"
 .PHONY: precheck

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,9 @@ ifeq ($(PDK),gf180mcuD)
 endif
 
 # Include Caravel Makefile Targets
-# .PHONY: % : check-caravel
-# %:
-# 	export CARAVEL_ROOT=$(CARAVEL_ROOT) && export MPW_TAG=$(MPW_TAG) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
+.PHONY: % : check-caravel
+%:
+	@export CARAVEL_ROOT=$(CARAVEL_ROOT) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
 
 # Install DV setup
 .PHONY: simenv
@@ -223,6 +223,45 @@ update_caravel: check-caravel
 uninstall:
 	rm -rf $(CARAVEL_ROOT)
 
+# Install Caravel
+.PHONY: install
+install: clean_log check-python check_dependencies install-volare
+	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
+	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool caravel
+
+# Install mgmt_core_wrapper
+.PHONY: install_mcw
+install_mcw: clean_log check-python check_dependencies install-volare
+	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
+	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool mgmt_core_wrapper
+
+# Install mgmt_core_wrapper
+.PHONY: pdk-with-volare
+pdk-with-volare: clean_log check-python check_dependencies install-volare
+	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
+	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool pdk
+
+# Install mgmt_core_wrapper
+.PHONY: openlane
+openlane: clean_log check-python check_dependencies install-volare
+	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
+	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool openlane
+
+
+# Install mgmt_core_wrapper
+.PHONY: setup-timing-scripts
+setup-timing-scripts: clean_log check-python check_dependencies install-volare
+	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
+	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool timing_scripts
+
+
+# Install mgmt_core_wrapper
+.PHONY: precheck
+precheck: clean_log check-python check_dependencies install-volare
+	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
+	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool precheck
+
+
 .PHONY: check_versions
 check_versions:
 	@if [ "$$DISABLE_VERSION_CHECK" = "1" ]; then\
@@ -230,17 +269,6 @@ check_versions:
 	else \
 		./venv/bin/$(PYTHON_BIN) -u scripts/compare_versions.py; \
 	fi
-# Install Pre-check
-# Default installs to the user home directory, override by "export PRECHECK_ROOT=<precheck-installation-path>"
-.PHONY: precheck
-precheck:
-	if [ -d "$(PRECHECK_ROOT)" ]; then\
-		echo "Deleting exisiting $(PRECHECK_ROOT)" && \
-		rm -rf $(PRECHECK_ROOT) && sleep 2;\
-	fi
-	@echo "Installing Precheck.."
-	@git clone --depth=1 --branch $(MPW_TAG) https://github.com/efabless/mpw_precheck.git $(PRECHECK_ROOT)
-	@docker pull efabless/mpw_precheck:latest
 
 .PHONY: run-precheck
 run-precheck: check_versions check-pdk check-precheck
@@ -324,14 +352,6 @@ export TIMING_ROOT?=$(shell pwd)/dependencies/timing-scripts
 export PROJECT_ROOT=$(CUP_ROOT)
 timing-scripts-repo=https://github.com/efabless/timing-scripts.git
 
-$(TIMING_ROOT):
-	@mkdir -p $(CUP_ROOT)/dependencies
-	@git clone $(timing-scripts-repo) $(TIMING_ROOT)
-
-.PHONY: setup-timing-scripts
-setup-timing-scripts: $(TIMING_ROOT)
-	@( cd $(TIMING_ROOT) && git pull )
-	@#( cd $(TIMING_ROOT) && git fetch && git checkout $(MPW_TAG); )
 
 .PHONY: install-caravel-cocotb
 install-caravel-cocotb:

--- a/Makefile
+++ b/Makefile
@@ -264,31 +264,32 @@ check_versions:
 
 .PHONY: run-precheck
 run-precheck: check_versions check-pdk check-precheck
-	@if [ "$$DISABLE_LVS" = "1" ]; then\
-		$(eval INPUT_DIRECTORY := $(shell pwd)) \
-		cd $(PRECHECK_ROOT) && \
-		docker run -it -v $(PRECHECK_ROOT):$(PRECHECK_ROOT) \
-		-v $(INPUT_DIRECTORY):$(INPUT_DIRECTORY) \
-		-v $(PDK_ROOT):$(PDK_ROOT) \
-		-e INPUT_DIRECTORY=$(INPUT_DIRECTORY) \
-		-e PDK_PATH=$(PDK_ROOT)/$(PDK) \
-		-e PDK_ROOT=$(PDK_ROOT) \
-		-e PDKPATH=$(PDKPATH) \
-		-u $(shell id -u $(USER)):$(shell id -g $(USER)) \
-		efabless/mpw_precheck:latest bash -c "cd $(PRECHECK_ROOT) ; python3 mpw_precheck.py --input_directory $(INPUT_DIRECTORY) --pdk_path $(PDK_ROOT)/$(PDK) license makefile default documentation consistency gpio_defines xor magic_drc klayout_feol klayout_beol klayout_offgrid klayout_met_min_ca_density klayout_pin_label_purposes_overlapping_drawing klayout_zeroarea"; \
-	else \
-		$(eval INPUT_DIRECTORY := $(shell pwd)) \
-		cd $(PRECHECK_ROOT) && \
-		docker run -it -v $(PRECHECK_ROOT):$(PRECHECK_ROOT) \
-		-v $(INPUT_DIRECTORY):$(INPUT_DIRECTORY) \
-		-v $(PDK_ROOT):$(PDK_ROOT) \
-		-e INPUT_DIRECTORY=$(INPUT_DIRECTORY) \
-		-e PDK_PATH=$(PDK_ROOT)/$(PDK) \
-		-e PDK_ROOT=$(PDK_ROOT) \
-		-e PDKPATH=$(PDKPATH) \
-		-u $(shell id -u $(USER)):$(shell id -g $(USER)) \
-		efabless/mpw_precheck:latest bash -c "cd $(PRECHECK_ROOT) ; python3 mpw_precheck.py --input_directory $(INPUT_DIRECTORY) --pdk_path $(PDK_ROOT)/$(PDK)"; \
-	fi
+	$(eval INPUT_DIRECTORY := $(shell pwd)) \
+	cd $(PRECHECK_ROOT) && \
+	docker run -it -v $(PRECHECK_ROOT):$(PRECHECK_ROOT) \
+	-v $(INPUT_DIRECTORY):$(INPUT_DIRECTORY) \
+	-v $(PDK_ROOT):$(PDK_ROOT) \
+	-e INPUT_DIRECTORY=$(INPUT_DIRECTORY) \
+	-e PDK_PATH=$(PDK_ROOT)/$(PDK) \
+	-e PDK_ROOT=$(PDK_ROOT) \
+	-e PDKPATH=$(PDKPATH) \
+	-u $(shell id -u $(USER)):$(shell id -g $(USER)) \
+	efabless/mpw_precheck:latest bash -c "cd $(PRECHECK_ROOT) ; python3 mpw_precheck.py --input_directory $(INPUT_DIRECTORY) --pdk_path $(PDK_ROOT)/$(PDK) --private"; \
+
+
+.PHONY: run-precheck-no-lvs
+run-precheck-no-lvs: check_versions check-pdk check-precheck
+	$(eval INPUT_DIRECTORY := $(shell pwd)) \
+	cd $(PRECHECK_ROOT) && \
+	docker run -it -v $(PRECHECK_ROOT):$(PRECHECK_ROOT) \
+	-v $(INPUT_DIRECTORY):$(INPUT_DIRECTORY) \
+	-v $(PDK_ROOT):$(PDK_ROOT) \
+	-e INPUT_DIRECTORY=$(INPUT_DIRECTORY) \
+	-e PDK_PATH=$(PDK_ROOT)/$(PDK) \
+	-e PDK_ROOT=$(PDK_ROOT) \
+	-e PDKPATH=$(PDKPATH) \
+	-u $(shell id -u $(USER)):$(shell id -g $(USER)) \
+	efabless/mpw_precheck:latest bash -c "cd $(PRECHECK_ROOT) ; python3 mpw_precheck.py --input_directory $(INPUT_DIRECTORY) --pdk_path $(PDK_ROOT)/$(PDK) license makefile consistency gpio_defines xor magic_drc klayout_feol klayout_beol klayout_offgrid klayout_met_min_ca_density klayout_pin_label_purposes_overlapping_drawing klayout_zeroarea oeb"; \
 
 
 BLOCKS = $(shell cd lvs && find * -maxdepth 0 -type d)

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ clean_log:
 .PHONY: print_message
 print_message:
 	@echo "Setting up caravel_user_project environment..."
-	@echo "To check for errors, please see setup.log"
+	@echo "To check for installation logs, please see setup.log"
 
 dv_patterns=$(shell cd verilog/dv && find * -maxdepth 0 -type d)
 cocotb-dv_patterns=$(shell cd verilog/dv/cocotb && find . -name "*.c"  | sed -e 's|^.*/||' -e 's/.c//')

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,9 @@ simenv-cocotb:
 setup: print_message clean_log check-python check_dependencies install-volare
 	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
 	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT)
+	@echo "installing cocotb..."
 	@$(MAKE) setup-cocotb >> setup.log
+	@echo "installation complete"
 
 .PHONY: install-volare
 install-volare:

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,9 @@ ifeq ($(PDK),gf180mcuD)
 endif
 
 # Include Caravel Makefile Targets
-.PHONY: % : check-caravel
-%:
-	export CARAVEL_ROOT=$(CARAVEL_ROOT) && export MPW_TAG=$(MPW_TAG) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
+# .PHONY: % : check-caravel
+# %:
+# 	export CARAVEL_ROOT=$(CARAVEL_ROOT) && export MPW_TAG=$(MPW_TAG) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
 
 # Install DV setup
 .PHONY: simenv

--- a/Makefile
+++ b/Makefile
@@ -416,17 +416,15 @@ extract-parasitics: check_versions ./verilog/gl/user_project_wrapper.v
 
 
 ifeq ($(wildcard ./tool_versions.json),)
-    # File doesn't exist
-    EXPORT_VARIABLE := 
+# File doesn't exist
+export OPENLANE_TAG=
+export OPEN_PDKS_COMMIT=
 else
-    # File exists
-    EXPORT_VARIABLE := $(shell jq -r '.OpenLane.commit' tool_versions.json)
+# File exists
+export OPENLANE_TAG=$(shell python3 ./scripts/export_env.py OpenLane)
+export OPEN_PDKS_COMMIT=$(shell python3 ./scripts/export_env.py pdk)
 endif
 
-export OPENLANE_TAG=$(EXPORT_VARIABLE)
-
-
-# export OPENLANE_TAG=$(shell jq -r '.OpenLane.commit' tool_versions.json)
 .PHONY: caravel-sta
 caravel-sta: check_versions ./env/spef-mapping.tcl
 	@$(MAKE) -C $(TIMING_ROOT) -f $(TIMING_ROOT)/timing.mk caravel-timing-typ -j3

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,9 @@ endif
 # Include Caravel Makefile Targets
 .PHONY: % : check-caravel
 %:
-	@export CARAVEL_ROOT=$(CARAVEL_ROOT) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@
+	@if [ -d "$(CARAVEL_ROOT)" ]; then \
+	@export CARAVEL_ROOT=$(CARAVEL_ROOT) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@; \
+	fi
 
 # Install DV setup
 .PHONY: simenv
@@ -188,16 +190,6 @@ make_what=setup $(blocks) $(dv-targets-rtl) $(dv-targets-gl) $(dv-targets-gl-sdf
 what:
 	# $(make_what)
 
-# Install Openlane
-.PHONY: openlane
-openlane:
-	@if [ "$$(realpath $${OPENLANE_ROOT})" = "$$(realpath $$(pwd)/openlane)" ]; then\
-		echo "OPENLANE_ROOT is set to '$$(pwd)/openlane' which contains openlane config files"; \
-		echo "Please set it to a different directory"; \
-		exit 1; \
-	fi
-	cd openlane && $(MAKE) openlane
-
 #### Not sure if the targets following are of any use
 
 # Create symbolic links to caravel's main files
@@ -235,27 +227,27 @@ install_mcw: clean_log check-python check_dependencies install-volare
 	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
 	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool mgmt_core_wrapper
 
-# Install mgmt_core_wrapper
+# Install pdk-with-volare
 .PHONY: pdk-with-volare
 pdk-with-volare: clean_log check-python check_dependencies install-volare
 	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
 	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool pdk
 
-# Install mgmt_core_wrapper
+# Install openlane
 .PHONY: openlane
 openlane: clean_log check-python check_dependencies install-volare
 	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
 	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool openlane
 
 
-# Install mgmt_core_wrapper
+# Install timing-scripts
 .PHONY: setup-timing-scripts
 setup-timing-scripts: clean_log check-python check_dependencies install-volare
 	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
 	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool timing_scripts
 
 
-# Install mgmt_core_wrapper
+# Install precheck
 .PHONY: precheck
 precheck: clean_log check-python check_dependencies install-volare
 	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log

--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,20 @@ extract-parasitics: check_versions ./verilog/gl/user_project_wrapper.v
 	@$(MAKE) -C $(TIMING_ROOT) -f $(TIMING_ROOT)/timing.mk rcx-user_project_wrapper
 	@cat ./tmp-macros-list
 	@rm ./tmp-macros-list
-	
+
+
+ifeq ($(wildcard ./tool_versions.json),)
+    # File doesn't exist
+    EXPORT_VARIABLE := 
+else
+    # File exists
+    EXPORT_VARIABLE := $(shell jq -r '.OpenLane.commit' tool_versions.json)
+endif
+
+export OPENLANE_TAG=$(EXPORT_VARIABLE)
+
+
+# export OPENLANE_TAG=$(shell jq -r '.OpenLane.commit' tool_versions.json)
 .PHONY: caravel-sta
 caravel-sta: check_versions ./env/spef-mapping.tcl
 	@$(MAKE) -C $(TIMING_ROOT) -f $(TIMING_ROOT)/timing.mk caravel-timing-typ -j3

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ pdk-with-volare: clean_log check-python check_dependencies install-volare
 .PHONY: openlane
 openlane: clean_log check-python check_dependencies install-volare
 	@./venv/bin/$(PYTHON_BIN) -m pip install --upgrade --no-cache-dir requests >> setup.log
-	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool openlane
+	@./venv/bin/$(PYTHON_BIN) -u scripts/get_tools.py --openlane_root $(OPENLANE_ROOT) --precheck_root $(PRECHECK_ROOT) --pdk_root $(PDK_ROOT) --caravel_root $(CARAVEL_ROOT) --mcw_root $(MCW_ROOT) --timing_root $(TIMING_ROOT) --tool OpenLane
 
 
 # Install timing-scripts

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ endif
 .PHONY: % : check-caravel
 %:
 	@if [ -d "$(CARAVEL_ROOT)" ]; then \
-	@export CARAVEL_ROOT=$(CARAVEL_ROOT) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@; \
+	export CARAVEL_ROOT=$(CARAVEL_ROOT) && $(MAKE) -f $(CARAVEL_ROOT)/Makefile $@; \
 	fi
 
 # Install DV setup

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,18 @@ blocks=$(shell cd openlane && find * -maxdepth 0 -type d)
 $(blocks): % : check_versions
 	$(MAKE) -C openlane $*
 
+# Openlane open last step gui using klayout
+blocks=$(shell cd openlane && find * -maxdepth 0 -type d)
+.PHONY: open-gui-%
+open-gui-% :
+	$(MAKE) -C openlane open-gui-$*
+
+# Openlane open last step gui using openroad
+blocks=$(shell cd openlane && find * -maxdepth 0 -type d)
+.PHONY: open-odb-gui-%
+open-odb-gui-% :
+	$(MAKE) -C openlane open-odb-gui-$*
+
 .PHONY: clean_log
 clean_log:
 	@rm -f setup.log

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -116,6 +116,22 @@ Starting your project
         ..
 
 		For an example of hardening a project please refer to `Hardening the User Project using OpenLane`_. .
+
+    *   In case a failure happens, view the last generated layout before failure:
+        - Last generated def file using klayout:
+
+        .. code:: bash
+
+           make open-gui-<module_name>	
+        ..
+
+        - Last generated odb file using openroad-gui:
+
+        .. code:: bash
+
+           make open-odb-gui-<module_name>	
+        ..
+
 	
 #.  Integrate modules into the user_project_wrapper
 

--- a/openlane/Makefile
+++ b/openlane/Makefile
@@ -37,6 +37,9 @@ openlane_cmd = \
 	-ignore_mismatches"
 openlane_cmd_interactive = "flow.tcl -it -file $$(realpath ./$*/interactive.tcl)"
 
+openlane_gui_klayout_cmd = "python3 $(OPENLANE_ROOT)/gui.py --viewer klayout --format def $$(realpath ./$*/runs/$*)"
+openlane_gui_openroad_cmd = "python3 $(OPENLANE_ROOT)/gui.py --viewer openroad --format odb $$(realpath ./$*/runs/$*)"
+
 docker_mounts = \
 	-v $$(realpath $(PWD)/..):$$(realpath $(PWD)/..) \
 	-v $(PDK_ROOT):$(PDK_ROOT) \
@@ -49,6 +52,13 @@ docker_env = \
 	-e MISMATCHES_OK=1 \
 	-e CARAVEL_ROOT=$(CARAVEL_ROOT) \
 	-e OPENLANE_RUN_TAG=$(OPENLANE_RUN_TAG)
+
+docker_extra_args = \
+	-e DISPLAY=$(DISPLAY) \
+	-v /tmp/.X11-unix:/tmp/.X11-unix \
+	-v $(HOME)/.Xauthority:/.Xauthority \
+	--network host \
+	--security-opt seccomp=unconfined
 
 ifneq ($(MCW_ROOT),)
 docker_env += -e MCW_ROOT=$(MCW_ROOT)
@@ -102,3 +112,14 @@ ifeq ($(OPENLANE_ROOT),)
 	@echo "Please export OPENLANE_ROOT"
 	@exit 1
 endif
+
+.PHONY: open-gui-%
+open-gui-%:
+	$(docker_run) $(docker_extra_args) \
+		$(OPENLANE_IMAGE_NAME) sh -c $(openlane_gui_klayout_cmd)
+
+.PHONY: open-odb-gui-%
+open-odb-gui-%:
+	$(docker_run) $(docker_extra_args) \
+		$(OPENLANE_IMAGE_NAME) sh -c $(openlane_gui_openroad_cmd)
+	

--- a/scripts/compare_versions.py
+++ b/scripts/compare_versions.py
@@ -19,25 +19,30 @@ import json
 
 
 def compare_json(tool_versions_json_path):
-    # Get the upstream JSON from the URL
-    upstream_url = 'https://raw.githubusercontent.com/efabless/central_CI/main/tools.json'
-    response = requests.get(upstream_url)
-    if response.status_code != 200:
-        raise ValueError(f'Failed to get upstream JSON from {upstream_url}: {response.status_code}')
-    upstream_json = response.json()
+    try:
+        # Get the upstream JSON from the URL
+        upstream_url = 'https://raw.githubusercontent.com/efabless/central_CI/main/tools.json'
+        response = requests.get(upstream_url)
+        if response.status_code != 200:
+            raise ValueError(f'Failed to get upstream JSON from {upstream_url}: {response.status_code}')
+        upstream_json = response.json()
 
-    if os.path.isfile(tool_versions_json_path):
-        with open(tool_versions_json_path, 'r') as tool_versions_file:
-            tool_versions_json = json.load(tool_versions_file)
-    else:
-        print("Couldn't find tool_versions.json, please run make setup")
-        exit(1)
+        if os.path.isfile(tool_versions_json_path):
+            with open(tool_versions_json_path, 'r') as tool_versions_file:
+                tool_versions_json = json.load(tool_versions_file)
+        else:
+            print("Couldn't find tool_versions.json, please run make setup")
+            exit(1)
 
-    # Compare the two JSON objects
-    if upstream_json == tool_versions_json:
-        print("The upstream JSON is the same as tool_versions.json")
-    else:
-        print("The upstream JSON is different from tool_versions.json, please update by running make setup")
+        # Compare the two JSON objects
+        if upstream_json == tool_versions_json:
+            print("The upstream JSON is the same as tool_versions.json")
+        else:
+            print("The upstream JSON is different from tool_versions.json, please update by running make setup")
+            exit(1)
+    except requests.exceptions.RequestException as e:
+        print("An error occurred while fetching data")
+        print("Please check your internet connection.")
         exit(1)
 
 

--- a/scripts/compare_versions.py
+++ b/scripts/compare_versions.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import json
 
@@ -10,9 +11,12 @@ def compare_json(tool_versions_json_path):
         raise ValueError(f'Failed to get upstream JSON from {upstream_url}: {response.status_code}')
     upstream_json = response.json()
 
-    # Load the tool_versions.json
-    with open(tool_versions_json_path, 'r') as tool_versions_file:
-        tool_versions_json = json.load(tool_versions_file)
+    if os.path.isfile(tool_versions_json_path):
+        with open(tool_versions_json_path, 'r') as tool_versions_file:
+            tool_versions_json = json.load(tool_versions_file)
+    else:
+        print("Couldn't find tool_versions.json, please run make setup")
+        exit(1)
 
     # Compare the two JSON objects
     if upstream_json == tool_versions_json:

--- a/scripts/compare_versions.py
+++ b/scripts/compare_versions.py
@@ -1,0 +1,25 @@
+import requests
+import json
+
+
+def compare_json(tool_versions_json_path):
+    # Get the upstream JSON from the URL
+    upstream_url = 'https://raw.githubusercontent.com/efabless/central_CI/main/tools.json'
+    response = requests.get(upstream_url)
+    if response.status_code != 200:
+        raise ValueError(f'Failed to get upstream JSON from {upstream_url}: {response.status_code}')
+    upstream_json = response.json()
+
+    # Load the tool_versions.json
+    with open(tool_versions_json_path, 'r') as tool_versions_file:
+        tool_versions_json = json.load(tool_versions_file)
+
+    # Compare the two JSON objects
+    if upstream_json == tool_versions_json:
+        print("The upstream JSON is the same as tool_versions.json")
+    else:
+        print("The upstream JSON is different from tool_versions.json, please update by running make setup")
+        exit(1)
+
+
+compare_json("./tool_versions.json")

--- a/scripts/compare_versions.py
+++ b/scripts/compare_versions.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: 2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 import os
 import requests
 import json

--- a/scripts/export_env.py
+++ b/scripts/export_env.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+
+
+def print_commit(tool_name):
+    with open('tool_versions.json', 'r') as file:
+        tool_versions_json = json.load(file)
+
+    if tool_name in tool_versions_json:
+        commit = tool_versions_json[tool_name]['commit']
+        print(commit)
+    else:
+        print("Invalid tool name")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('tool_name', help='Name of the tool to print the commit for')
+    args = parser.parse_args()
+
+    print_commit(args.tool_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/get_tools.py
+++ b/scripts/get_tools.py
@@ -52,7 +52,7 @@ def parse_json_file(url):
     return data
 
 
-def download_tools(openlane_root, precheck_root, pdk_root, caravel_root, mcw_root, timing_root):
+def download_tools(openlane_root, precheck_root, pdk_root, caravel_root, mcw_root, timing_root, tool):
     """Downloads the tools from the upstream GitHub repo.
     """
     url = 'https://raw.githubusercontent.com/efabless/central_CI/main/tools.json'
@@ -61,6 +61,8 @@ def download_tools(openlane_root, precheck_root, pdk_root, caravel_root, mcw_roo
     with Progress(TextColumn("[progress.description]{task.description}"), BarColumn(), MofNCompleteColumn(), TimeElapsedColumn()) as progress:
         task = progress.add_task("[cyan]Downloading Tools...", total=6)
         for key, value in data.items():
+            if tool and key != tool:
+                continue
             if key == "OpenLane":
                 progress.update(task, description="[cyan]Downloading OpenLane...")
                 download_tar("OpenLane", value['commit'], value['url'], openlane_root)
@@ -133,6 +135,8 @@ def main():
                         help='Path to the Mgmt Core Wrapper root directory')
     parser.add_argument('--timing_root', required=True,
                         help='Path to the Timing Scripts root directory')
+    parser.add_argument('--tool', required=False,
+                        help='Name of the tool to download')
 
     args = parser.parse_args()
     download_tools(openlane_root=args.openlane_root,
@@ -140,7 +144,8 @@ def main():
                    pdk_root=args.pdk_root,
                    caravel_root=args.caravel_root,
                    mcw_root=args.mcw_root,
-                   timing_root=args.timing_root)
+                   timing_root=args.timing_root,
+                   tool=args.tool)
 
 
 if __name__ == '__main__':

--- a/scripts/get_tools.py
+++ b/scripts/get_tools.py
@@ -59,7 +59,10 @@ def download_tools(openlane_root, precheck_root, pdk_root, caravel_root, mcw_roo
     data = parse_json_file(url)
     f = open("setup.log", "a")
     with Progress(TextColumn("[progress.description]{task.description}"), BarColumn(), MofNCompleteColumn(), TimeElapsedColumn()) as progress:
-        task = progress.add_task("[cyan]Downloading Tools...", total=6)
+        if tool:
+            task = progress.add_task("[cyan]Downloading Tools...", total=1)
+        else:
+            task = progress.add_task("[cyan]Downloading Tools...", total=6)
         for key, value in data.items():
             if tool and key != tool:
                 continue

--- a/scripts/get_tools.py
+++ b/scripts/get_tools.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: 2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import json
 import os

--- a/scripts/get_tools.py
+++ b/scripts/get_tools.py
@@ -1,0 +1,113 @@
+import argparse
+import json
+import os
+import shutil
+import tarfile
+import requests
+import volare
+from rich.progress import Progress
+
+
+def parse_json_file(url):
+    """Parses a JSON file from the given URL.
+
+    Args:
+    url: The URL of the JSON file.
+
+    Returns:
+    A Python dictionary containing the parsed JSON data.
+    """
+
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise ValueError(f'Failed to get JSON data from {url}: {response.status_code}')
+
+    data = response.json()
+    json_data = json.dumps(data, indent=4)
+    # Write the JSON data to a file
+    with open('tool_versions.json', 'w') as file:
+        file.write(json_data)
+    return data
+
+
+def download_tools(openlane_root, precheck_root, pdk_root, caravel_root, mcw_root, timing_root):
+    """Downloads the tools from the upstream GitHub repo.
+    """
+    url = 'https://raw.githubusercontent.com/efabless/central_CI/main/tools.json'
+    data = parse_json_file(url)
+    with Progress() as progress:
+        task = progress.add_task("[cyan]Downloading Tools...", total=6)
+        for key, value in data.items():
+            if key == "OpenLane":
+                progress.update(task, description="[cyan]Downloading OpenLane...")
+                download_tar("OpenLane", value['commit'], value['url'], openlane_root)
+                progress.update(task, completed=1)
+            elif key == "pdk":
+                progress.update(task, description="[cyan]Downloading pdk...")
+                volare.enable(pdk_root, "sky130", value['commit'])
+                progress.update(task, completed=1)
+            elif key == "precheck":
+                progress.update(task, description="[cyan]Downloading precheck...")
+                download_tar("precheck", value['commit'], value['url'], precheck_root)
+                progress.update(task, completed=1)
+            elif key == "caravel":
+                progress.update(task, description="[cyan]Downloading caravel...")
+                download_tar("caravel", value['commit'], value['url'], caravel_root)
+                progress.update(task, completed=1)
+            elif key == "mgmt_core_wrapper":
+                progress.update(task, description="[cyan]Downloading mgmt_core_wrapper...")
+                download_tar("mgmt_core_wrapper", value['commit'], value['url'], mcw_root)
+                progress.update(task, completed=1)
+            elif key == "timing_scripts":
+                progress.update(task, description="[cyan]Downloading timing_scripts...")
+                download_tar("timing_scripts", value['commit'], value['url'], timing_root)
+                progress.update(task, completed=1)
+
+
+def download_tar(tool, version, url, tool_path):
+    if os.path.isdir(tool_path):
+        shutil.rmtree(tool_path)
+    os.makedirs(tool_path)
+    name = url.split("/")[-1]
+    owner = url.split("/")[-2]
+    # print(f"downloading {tool}")
+    response = requests.get(f'{url}/tarball/{version}')
+    if response.status_code != 200:
+        raise Exception(f"Failed to download {tool}")
+    with open(f'{os.path.dirname(tool_path)}/{version}.tar.gz', 'wb') as file:
+        file.write(response.content)
+    # print(f"extracting {os.path.dirname(tool_path)}/{version}.tar.gz")
+
+    tar = tarfile.open(f'{os.path.dirname(tool_path)}/{version}.tar.gz', 'r:gz')
+    tar.extractall(path=os.path.dirname(tool_path))
+    tar.close()
+    os.rename(f'{os.path.dirname(tool_path)}/{owner}-{name}-{version[0:7]}', f'{tool_path}')
+    os.remove(f'{os.path.dirname(tool_path)}/{version}.tar.gz')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--openlane_root', required=True,
+                        help='Path to the OpenLANE root directory')
+    parser.add_argument('--precheck_root', required=True,
+                        help='Path to the Precheck root directory')
+    parser.add_argument('--pdk_root', required=True,
+                        help='Path to the PDK root directory')
+    parser.add_argument('--caravel_root', required=True,
+                        help='Path to the Caravel root directory')
+    parser.add_argument('--mcw_root', required=True,
+                        help='Path to the Mgmt Core Wrapper root directory')
+    parser.add_argument('--timing_root', required=True,
+                        help='Path to the Timing Scripts root directory')
+
+    args = parser.parse_args()
+    download_tools(openlane_root=args.openlane_root,
+                   precheck_root=args.precheck_root,
+                   pdk_root=args.pdk_root,
+                   caravel_root=args.caravel_root,
+                   mcw_root=args.mcw_root,
+                   timing_root=args.timing_root)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/get_tools.py
+++ b/scripts/get_tools.py
@@ -53,26 +53,33 @@ def download_tools(openlane_root, precheck_root, pdk_root, caravel_root, mcw_roo
                 os.environ['OPENLANE_IMAGE_NAME'] = f"efabless/openlane:{value['commit']}"
                 os.environ['IMAGE_NAME'] = f"efabless/openlane:{value['commit']}"
                 subprocess.run(["make", "pull-openlane"], cwd=openlane_root, env=os.environ, stderr=subprocess.STDOUT, text=True, check=True, stdout=f)
+                print("OpenLane downloaded successfully")
                 progress.update(task, advance=1)
             elif key == "pdk":
                 progress.update(task, description="[cyan]Downloading pdk...")
+                progress.stop()
                 volare.enable(pdk_root, "sky130", value['commit'])
+                progress.start()
                 progress.update(task, advance=1)
             elif key == "precheck":
-                progress.update(task, description="[cyan]Downloading precheck...")
+                progress.update(task, description="[cyan]Downloading mpw_precheck...")
                 download_tar("precheck", value['commit'], value['url'], precheck_root)
+                print("mpw_precheck downloaded successfully")
                 progress.update(task, advance=1)
             elif key == "caravel":
                 progress.update(task, description="[cyan]Downloading caravel...")
                 download_tar("caravel", value['commit'], value['url'], caravel_root)
+                print("caravel downloaded successfully")
                 progress.update(task, advance=1)
             elif key == "mgmt_core_wrapper":
                 progress.update(task, description="[cyan]Downloading mgmt_core_wrapper...")
                 download_tar("mgmt_core_wrapper", value['commit'], value['url'], mcw_root)
+                print("mgmt_core_wrapper downloaded successfully")
                 progress.update(task, advance=1)
             elif key == "timing_scripts":
                 progress.update(task, description="[cyan]Downloading timing_scripts...")
                 download_tar("timing_scripts", value['commit'], value['url'], timing_root)
+                print("timing_scripts downloaded successfully")
                 progress.update(task, advance=1)
 
 


### PR DESCRIPTION
_Originally created by marwaneltoukhy on 2023-11-29T14:17:59Z_

This PR is intended to solve user issues where the environment isn't up to date with the latest releases from efabless.

1. change `make setup` to use a python script, making it easier to download and prettier
2. `make setup` now uses central CI repo to fetch the versions from upstream
3. `make setup` outputs `tool_versions.json` to indicate which tools the user is using in their environment
4. `make setup` now has a log file called `setup.log`
5. all targets run `check_environment` which checks their tools versions and compares it to the upstream json file, if any version is outdated it will throw an error and exit
6. Added 2 targets to open last failed run's layout `open-gui-<module-name>` and `open-odb-gui-<module_name>`