### PR TITLE
update librelane to CC2509b

### DIFF
--- a/openlane/.gitignore
+++ b/openlane/.gitignore
@@ -1,3 +1,4 @@
 */runs
 default.cvcrc
 .venv/
+.version-*

--- a/openlane/Makefile
+++ b/openlane/Makefile
@@ -26,8 +26,8 @@ SHELL := /bin/bash
 ifeq ($(origin LIBRELANE_RUN_TAG), undefined)
 export LIBRELANE_RUN_TAG := $(shell date '+%y_%m_%d_%H_%M')
 endif
-ifeq ($(origin LIBRELANE_TAG), undefined)
-export CF_LIBRELANE_TAG := CC2509
+ifeq ($(origin CF_LIBRELANE_TAG), undefined)
+export CF_LIBRELANE_TAG := CC2509b
 endif
 
 export CARAVEL_ROOT := $(CARAVEL_ROOT)
@@ -90,12 +90,16 @@ librelane-docker-image:
 	@echo "LibreLane will automatically pull the appropriate Docker image as needed."
 
 librelane-venv: $(PROJECT_ROOT)/openlane/.venv/manifest.txt
-$(PROJECT_ROOT)/openlane/.venv/manifest.txt:
+$(PROJECT_ROOT)/openlane/.venv/manifest.txt: $(PROJECT_ROOT)/openlane/.version-$(CF_LIBRELANE_TAG)
 	rm -rf $(PROJECT_ROOT)/openlane/.venv
 	python3 -m venv $(PROJECT_ROOT)/openlane/.venv
 	PYTHONPATH= $(PROJECT_ROOT)/openlane/.venv/bin/python3 -m pip install --upgrade pip
 	PYTHONPATH= $(PROJECT_ROOT)/openlane/.venv/bin/python3 -m pip install "https://github.com/chipfoundry/openlane-2/tarball/$(CF_LIBRELANE_TAG)"
 	PYTHONPATH= $(PROJECT_ROOT)/openlane/.venv/bin/python3 -m pip freeze > $@
+	
+$(PROJECT_ROOT)/openlane/.version-$(CF_LIBRELANE_TAG):
+	echo "$(CF_LIBRELANE_TAG)" > $@
+	python3 -c 'import os; [os.remove(f) for f in os.listdir("$(@D)") if f.startswith(".version-") and f != os.path.basename("$@")]'
 
 .PHONY: librelane-nix
 librelane-nix:


### PR DESCRIPTION
Resolves issues with podman-based setups.

Also add a Makefile stamp-based target so if the value of CF_LIBRELANE_TAG changes, the venv is rebuilt without having to manually delete it.