### PR TITLE
Fix cocotb counter_wb test failing due to timeout

### DIFF
--- a/verilog/dv/cocotb/user_proj_tests/counter_wb/counter_wb.py
+++ b/verilog/dv/cocotb/user_proj_tests/counter_wb/counter_wb.py
@@ -22,7 +22,7 @@ import cocotb
 @cocotb.test()
 @report_test
 async def counter_wb(dut):
-    caravelEnv = await test_configure(dut,timeout_cycles=22620)
+    caravelEnv = await test_configure(dut,timeout_cycles=29534)
 
     cocotb.log.info(f"[TEST] Start counter_wb test")  
     # wait for start of sending


### PR DESCRIPTION
Currently, the cocotb counter_wb test fails in a fresh clone due to reaching a timeout.

I've increased the timeout parameter for the configuration of caravel in the cocotb test, which allows the test to complete successfully.