### PR TITLE
Add files generated by caravel gen_gpio_defaults.py script to includes

### DIFF
--- a/verilog/includes/includes.gl+sdf.caravel_user_project
+++ b/verilog/includes/includes.gl+sdf.caravel_user_project
@@ -16,3 +16,8 @@
 // Caravel user project includes		
 $USER_PROJECT_VERILOG/gl/user_project_wrapper.v
 $USER_PROJECT_VERILOG/gl/user_proj_example.v
+
+// Automatically generated with user I/O config from user_defines.v
+// by caravel/scripts/gen_gpio_defaults.py
+$USER_PROJECT_VERILOG/gl/caravel_core.v
+$USER_PROJECT_VERILOG/gl/gpio_defaults_block_*.v

--- a/verilog/includes/includes.gl.caravel_user_project
+++ b/verilog/includes/includes.gl.caravel_user_project
@@ -17,10 +17,7 @@
 -v $(USER_PROJECT_VERILOG)/gl/user_project_wrapper.v    
 -v $(USER_PROJECT_VERILOG)/gl/user_proj_example.v
 
+# Automatically generated with user I/O config from user_defines.v
+# by caravel/scripts/gen_gpio_defaults.py
 -v $(USER_PROJECT_VERILOG)/gl/caravel_core.v
-
-# default should be added according to the defaults used
-
-#-v $(USER_PROJECT_VERILOG)/gl/gpio_defaults_block_0403.v     
-#-v $(USER_PROJECT_VERILOG)/gl/gpio_defaults_block_0801.v     
-#-v $(USER_PROJECT_VERILOG)/gl/gpio_defaults_block_1803.v 
+-v $(USER_PROJECT_VERILOG)/gl/gpio_defaults_block_*.v


### PR DESCRIPTION
- Use a wildcard to include the `gpio_defaults_block_*.v` files
- Add files to `includes.gl+sdf.caravel_user_project`