### PR TITLE
Fix setup-cocotb-env to use venv-cocotb Python interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ install-caravel-cocotb:
 
 .PHONY: setup-cocotb-env
 setup-cocotb-env:
-	@(python3 $(PROJECT_ROOT)/verilog/dv/setup-cocotb.py $(CARAVEL_ROOT) $(MCW_ROOT) $(PDK_ROOT) $(PDK) $(PROJECT_ROOT))
+	@($(PROJECT_ROOT)/venv-cocotb/bin/python3 $(PROJECT_ROOT)/verilog/dv/setup-cocotb.py $(CARAVEL_ROOT) $(MCW_ROOT) $(PDK_ROOT) $(PDK) $(PROJECT_ROOT))
 
 .PHONY: setup-cocotb
 setup-cocotb: install-caravel-cocotb setup-cocotb-env simenv-cocotb


### PR DESCRIPTION
The setup-cocotb.py script requires the click module which is installed in venv-cocotb. Using system python3 causes ModuleNotFoundError.

Changed from:
  python3 /verilog/dv/setup-cocotb.py ...

To:
  /venv-cocotb/bin/python3 /verilog/dv/setup-cocotb.py ...

This ensures the script uses the correct Python interpreter with all required dependencies installed.